### PR TITLE
New game input bug

### DIFF
--- a/js/views/lettr-view.js
+++ b/js/views/lettr-view.js
@@ -177,6 +177,7 @@
             this.guessWordsContainer.innerHTML = '';
             this.formLetterRadioOption.checked = true;
             this.formWordRadioOption.checked = false;
+            app.lettrView.userGuessInput.setAttribute('maxlength', '1');
         },
         render: function() {
             this.displayWord();

--- a/js/views/lettr-view.js
+++ b/js/views/lettr-view.js
@@ -177,7 +177,7 @@
             this.guessWordsContainer.innerHTML = '';
             this.formLetterRadioOption.checked = true;
             this.formWordRadioOption.checked = false;
-            app.lettrView.userGuessInput.setAttribute('maxlength', '1');
+            this.setGuessInputMaxLength();
         },
         render: function() {
             this.displayWord();


### PR DESCRIPTION
I added the missing function call from clearBoardView that resets the max length of the word guess input when a new game is started.